### PR TITLE
Issue#3

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Exemplo:
 
 #### Tirando uma foto pela API
 
-O módulo de fotos está desprendido do Gibot. Você pode desenvolver a sua própria API de foto dentro do Gibot e fazer com que ela acesse a câmera que deseja manusear, entretanto, ,por hora, essa API ficará em uma outra aplicação pois possui um escopo diferente da proposta do Gibot.
+O módulo de fotos está desprendido do Gibot. Você pode desenvolver a sua própria API de foto dentro do Gibot e fazer com que ela acesse a câmera que deseja manusear, entretanto, por hora, essa API ficará em uma outra aplicação pois possui um escopo diferente da proposta do Gibot.
 
 ## 5. Reddit
 

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Exemplo:
 
 #### Tirando uma foto pela API
 
-O módulo de fotos está desprendido do Gibot. Você pode desenvolver a sua própria API de foto dentro do Gibot e fazer com que ela acesse a câmera que deseja manusear, entretanto por hora essa API ficará em uma outra aplicação pois possui um escopo diferente da proposta do Gibot.
+O módulo de fotos está desprendido do Gibot. Você pode desenvolver a sua própria API de foto dentro do Gibot e fazer com que ela acesse a câmera que deseja manusear, entretanto, ,por hora, essa API ficará em uma outra aplicação pois possui um escopo diferente da proposta do Gibot.
 
 ## 5. Reddit
 


### PR DESCRIPTION
Typo: caso de vírgula do tipo aposto no read me.

> **Tirando uma foto pela API**
> 
> O módulo de fotos está desprendido do Gibot. Você pode desenvolver a sua própria API de foto dentro do Gibot e fazer com que ela acesse a câmera que deseja manusear, entretanto por hora essa API ficará em uma outra aplicação pois possui um escopo diferente da proposta do Gibot.